### PR TITLE
fix(appimage): bundle libpython + add release smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install system dependencies
         run: |
@@ -57,6 +57,21 @@ jobs:
         run: |
           chmod +x packaging/appimage/build-appimage.sh
           ./packaging/appimage/build-appimage.sh
+
+      - name: Smoke test AppImage
+        # Runs --version against the just-built AppImage to catch dynamic-linker
+        # regressions (missing libpython, etc.) before publishing. Fails the job
+        # — and therefore the release — if the AppImage can't even start.
+        run: |
+          set -euxo pipefail
+          chmod +x dist/*.AppImage
+          EXPECTED_VERSION="${GITHUB_REF#refs/tags/v}"
+          OUTPUT=$(./dist/*.AppImage --version 2>&1)
+          echo "AppImage --version output: ${OUTPUT}"
+          if ! echo "${OUTPUT}" | grep -q "${EXPECTED_VERSION}"; then
+            echo "::error::AppImage --version did not report expected version ${EXPECTED_VERSION}"
+            exit 1
+          fi
 
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v7

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -59,6 +59,24 @@ for lib in "${LIBS[@]}"; do
     fi
 done
 
+# Bundle libpython so the AppImage runs on systems without matching system Python.
+#
+# Two cases by how the bundled python3 binary is linked:
+#   1. DYNAMIC (GitHub Actions toolcache Python, custom builds): libpython
+#      shows up in `ldd python3` and MUST be bundled — otherwise the AppImage
+#      breaks on any host without a matching libpythonX.Y.so. This is the
+#      bug fixed in v1.7.1 (CI builds were dynamic + libpython unbundled).
+#   2. STATIC (Ubuntu distro python3): libpython is compiled into the binary,
+#      so `ldd` shows nothing and there's nothing to bundle. Fine to skip.
+echo "=== Bundling libpython ==="
+LIBPYTHON_PATH=$(ldd "$(which python3)" 2>/dev/null | grep -oP '/[^ ]*libpython[^ ]+\.so[^ ]*' | head -1)
+if [ -n "${LIBPYTHON_PATH}" ] && [ -f "${LIBPYTHON_PATH}" ]; then
+    echo "Found dynamic libpython at: ${LIBPYTHON_PATH}"
+    cp -L "${LIBPYTHON_PATH}" "${APPDIR}/usr/lib/"
+else
+    echo "No dynamic libpython detected (python3 appears statically linked). Skipping bundle."
+fi
+
 echo "=== Setting up AppImage structure ==="
 # Copy AppRun
 cp "${SCRIPT_DIR}/AppRun" "${APPDIR}/"


### PR DESCRIPTION
## Summary

Fixes the v1.7.0 AppImage which was unusable on Ubuntu 24.04 hosts due to a missing `libpython3.X.so` in the AppDir. Adds a CI smoke test that catches the same class of bug going forward.

## Root cause

`packaging/appimage/build-appimage.sh` copied the python3 binary and the stdlib but never copied `libpython3.X.so` — and the GitHub-Actions-provided python3 is dynamically linked to it. Combined with `release.yml` pinning `python-version: 3.11` (vs Noble's 3.12 default), every AppImage we shipped was DOA on current Ubuntu LTS.

## Changes

1. **`build-appimage.sh`** — Use `ldd` to discover the libpython dependency of the bundled python3 binary; copy it into `AppDir/usr/lib/`. Handles both dynamic-link (CI builds) and static-link (Ubuntu distro python3) cases.

2. **`release.yml`** — Bump `python-version: 3.11 → 3.12` to align with Noble LTS.

3. **`release.yml`** — New "Smoke test AppImage" step. Runs `--version` against the freshly-built AppImage and asserts the tag version appears in the output. Fails the release workflow before publishing if the AppImage can't start.

## Test plan

- [ ] CI green on this branch (no regression to existing test/lint/build/security/typecheck)
- [ ] After merge: tag `v1.7.1`, watch release workflow, confirm Smoke Test step passes
- [ ] After release: download AppImage on Ubuntu 24.04 box, run `./G13_Linux-1.7.1-x86_64.AppImage --version`, expect `g13-linux 1.7.1` (no `libpython` error)
- [ ] Update local `~/Applications/` with working AppImage

**Caveat:** This branch's CI only runs `ci.yml`, not `release.yml`. The smoke test step itself is exercised only at tag-push time. If the smoke test step has a bug, easy fix-forward via v1.7.2.

## Discovered

After tonight's v1.7.0 ship, `pipx upgrade g13-linux` worked fine and the new diagnostics are hardware-verified, but `~/Applications/G13_Linux-1.7.0-x86_64.AppImage --version` died with `libpython3.11.so.1.0: cannot open shared object file` on Ubuntu 24.04. The pipx install is the canonical CLI path; this fix gets the AppImage back to "actually works" for desktop users who don't want to touch pip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)