### PR TITLE
feat(joystick): support modifier+key combos for digital direction keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-05-03
+
+### Added
+- Joystick directions (`joystick.key_up/key_down/key_left/key_right`) now accept modifier+key combos as a JSON list, e.g. `"key_up": ["KEY_LEFTCTRL", "KEY_L"]`. Previously only single keys were supported, so EVE-style "Ctrl+L = lock target" couldn't be bound to a stick direction without rebinding the game.
+
+### Changed
+- `JoystickConfig.key_up/key_down/key_left/key_right` are now stored as `tuple[str, ...]` internally. `__post_init__` coerces strings/lists to tuples so existing call sites (`JoystickConfig(key_up="KEY_W")`) keep working unchanged.
+- Single-key direction profiles still serialize as bare strings in JSON for backward compat. Combo directions serialize as lists.
+
+### Fixed
+- Legacy directional mapping objects (`{"keys": ["KEY_LEFTALT", "KEY_LEFT"]}` under `up`/`down`/`left`/`right`) now preserve all keys in the combo. Pre-1.7.2 the parser dropped everything except the first key.
+
 ## [1.7.1] - 2026-05-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "g13-linux"
-version = "1.7.1"
+version = "1.7.2"
 description = "Logitech G13 Linux driver with macro support, RGB control, and LCD display management"
 readme = "README.md"
 license = "MIT"

--- a/src/g13_linux/gui/models/joystick_handler.py
+++ b/src/g13_linux/gui/models/joystick_handler.py
@@ -76,47 +76,79 @@ class JoystickConfig:
     deadzone: int = 20  # Center deadzone (0-127)
     sensitivity: float = 1.0  # Axis sensitivity multiplier
 
-    # Digital mode key mappings (evdev key names)
-    key_up: str = "KEY_UP"
-    key_down: str = "KEY_DOWN"
-    key_left: str = "KEY_LEFT"
-    key_right: str = "KEY_RIGHT"
+    # Digital mode key mappings (evdev key names).
+    # Each direction can be a single key OR a modifier combo (e.g. Ctrl+L).
+    # Stored as a tuple so the dataclass default is hashable. JSON profiles
+    # can specify either a string ("KEY_L") or a list (["KEY_LEFTCTRL", "KEY_L"])
+    # — both are normalized to a tuple via _parse_key_mapping.
+    key_up: tuple[str, ...] = ("KEY_UP",)
+    key_down: tuple[str, ...] = ("KEY_DOWN",)
+    key_left: tuple[str, ...] = ("KEY_LEFT",)
+    key_right: tuple[str, ...] = ("KEY_RIGHT",)
 
     # Diagonal support
     allow_diagonals: bool = True
 
-    @staticmethod
-    def _parse_key_mapping(value, default: str) -> str:
+    def __post_init__(self):
+        """Normalize key_* fields to tuples regardless of caller input shape.
+
+        Allows direct construction with strings (legacy) or lists, e.g.:
+            JoystickConfig(key_up="KEY_W")
+            JoystickConfig(key_up=["KEY_LEFTCTRL", "KEY_L"])
+        Both end up as tuples internally.
         """
-        Parse key mapping from modern or legacy profile formats.
+        self.key_up = self._coerce_key_seq(self.key_up)
+        self.key_down = self._coerce_key_seq(self.key_down)
+        self.key_left = self._coerce_key_seq(self.key_left)
+        self.key_right = self._coerce_key_seq(self.key_right)
+
+    @staticmethod
+    def _coerce_key_seq(value) -> tuple[str, ...]:
+        """Coerce a value (str/list/tuple) into a tuple of key names."""
+        if isinstance(value, tuple):
+            return value
+        if isinstance(value, str):
+            return (value,)
+        if isinstance(value, list):
+            return tuple(v for v in value if isinstance(v, str))
+        return (str(value),)
+
+    @staticmethod
+    def _parse_key_mapping(value, default: str) -> tuple[str, ...]:
+        """
+        Parse key mapping from modern, combo, or legacy profile formats.
+
+        Returns a tuple of evdev key names. Single-key values become a
+        1-tuple; combos return all modifier+key components in order.
 
         Supported formats:
-        - "KEY_W" (modern flat string)
-        - {"keys": ["KEY_LEFTALT", "KEY_LEFT"], ...} (legacy directional mapping)
-        - ["KEY_W", ...] (fallback)
+        - "KEY_W" → ("KEY_W",)
+        - ["KEY_LEFTCTRL", "KEY_L"] → ("KEY_LEFTCTRL", "KEY_L")
+        - {"keys": ["KEY_LEFTCTRL", "KEY_L"], ...} → ("KEY_LEFTCTRL", "KEY_L")
+        - {"key": "KEY_W"} → ("KEY_W",)
         """
         if isinstance(value, str):
-            return value
+            return (value,)
 
         if isinstance(value, dict):
             keys = value.get("keys", [])
             if isinstance(keys, list):
-                for key_name in keys:
-                    if isinstance(key_name, str):
-                        return key_name
+                collected = tuple(k for k in keys if isinstance(k, str))
+                if collected:
+                    return collected
 
             key_name = value.get("key")
             if isinstance(key_name, str):
-                return key_name
+                return (key_name,)
 
-            return default
+            return (default,)
 
         if isinstance(value, list | tuple):
-            for key_name in value:
-                if isinstance(key_name, str):
-                    return key_name
+            collected = tuple(k for k in value if isinstance(k, str))
+            if collected:
+                return collected
 
-        return default
+        return (default,)
 
     @classmethod
     def from_dict(cls, data: dict) -> "JoystickConfig":
@@ -160,15 +192,24 @@ class JoystickConfig:
         )
 
     def to_dict(self) -> dict:
-        """Convert to dict (profile saving)"""
+        """Convert to dict (profile saving).
+
+        For backward compatibility, single-key directions serialize as strings
+        (the legacy format). Combos serialize as lists. This way pre-combo
+        profiles round-trip identically.
+        """
+
+        def _serialize(keys: tuple[str, ...]):
+            return keys[0] if len(keys) == 1 else list(keys)
+
         return {
             "mode": self.mode.value,
             "deadzone": self.deadzone,
             "sensitivity": self.sensitivity,
-            "key_up": self.key_up,
-            "key_down": self.key_down,
-            "key_left": self.key_left,
-            "key_right": self.key_right,
+            "key_up": _serialize(self.key_up),
+            "key_down": _serialize(self.key_down),
+            "key_left": _serialize(self.key_left),
+            "key_right": _serialize(self.key_right),
             "allow_diagonals": self.allow_diagonals,
         }
 
@@ -231,16 +272,17 @@ class JoystickHandler:
 
     def _start_digital(self):
         """Create keyboard device for direction keys"""
-        # Collect all configured keys
+        # Collect all configured keys (each direction may be a combo, so flatten)
         keys = set()
-        for key_name in [
+        for key_tuple in [
             self.config.key_up,
             self.config.key_down,
             self.config.key_left,
             self.config.key_right,
         ]:
-            if hasattr(e, key_name):
-                keys.add(getattr(e, key_name))
+            for key_name in key_tuple:
+                if hasattr(e, key_name):
+                    keys.add(getattr(e, key_name))
 
         if keys:
             self._key_device = UInput({e.EV_KEY: list(keys)}, name="G13 Joystick Keys")
@@ -316,25 +358,30 @@ class JoystickHandler:
         up = centered_y < -deadzone  # Y is inverted (up = negative)
         down = centered_y > deadzone
 
-        # Build set of keys that should be pressed
+        # Build set of keys that should be pressed.
+        # Each direction may be a combo (e.g. Ctrl+L), so .update() with the
+        # whole tuple — not .add() of a single key.
         should_press: set[str] = set()
 
         if up:
-            should_press.add(self.config.key_up)
+            should_press.update(self.config.key_up)
         if down:
-            should_press.add(self.config.key_down)
+            should_press.update(self.config.key_down)
         if left:
-            should_press.add(self.config.key_left)
+            should_press.update(self.config.key_left)
         if right:
-            should_press.add(self.config.key_right)
+            should_press.update(self.config.key_right)
 
-        # Handle diagonal restriction
-        if not self.config.allow_diagonals and len(should_press) > 1:
+        # Handle diagonal restriction.
+        # NOTE: count by number of *active directions*, not number of keys
+        # (a single combo direction can produce 2+ keys).
+        active_dirs = sum([up, down, left, right])
+        if not self.config.allow_diagonals and active_dirs > 1:
             # Pick the dominant direction (larger magnitude)
             if abs(centered_x) > abs(centered_y):
-                should_press = {self.config.key_left if left else self.config.key_right}
+                should_press = set(self.config.key_left if left else self.config.key_right)
             else:
-                should_press = {self.config.key_up if up else self.config.key_down}
+                should_press = set(self.config.key_up if up else self.config.key_down)
 
         # Release keys that should no longer be pressed
         for key_name in self._keys_pressed - should_press:

--- a/tests/test_joystick_handler.py
+++ b/tests/test_joystick_handler.py
@@ -30,10 +30,12 @@ class TestJoystickConfig:
         assert config.mode == JoystickMode.ANALOG
         assert config.deadzone == 20
         assert config.sensitivity == 1.0
-        assert config.key_up == "KEY_UP"
-        assert config.key_down == "KEY_DOWN"
-        assert config.key_left == "KEY_LEFT"
-        assert config.key_right == "KEY_RIGHT"
+        # Direction keys are normalized to tuples (single keys are 1-tuples,
+        # combos are N-tuples). See JoystickConfig._coerce_key_seq.
+        assert config.key_up == ("KEY_UP",)
+        assert config.key_down == ("KEY_DOWN",)
+        assert config.key_left == ("KEY_LEFT",)
+        assert config.key_right == ("KEY_RIGHT",)
         assert config.allow_diagonals is True
 
     def test_from_dict_defaults(self):
@@ -56,10 +58,10 @@ class TestJoystickConfig:
         assert config.mode == JoystickMode.DIGITAL
         assert config.deadzone == 30
         assert config.sensitivity == 1.5
-        assert config.key_up == "KEY_W"
-        assert config.key_down == "KEY_S"
-        assert config.key_left == "KEY_A"
-        assert config.key_right == "KEY_D"
+        assert config.key_up == ("KEY_W",)
+        assert config.key_down == ("KEY_S",)
+        assert config.key_left == ("KEY_A",)
+        assert config.key_right == ("KEY_D",)
         assert config.allow_diagonals is False
 
     def test_from_dict_invalid_mode(self):
@@ -69,6 +71,49 @@ class TestJoystickConfig:
     def test_from_dict_legacy_directional_mode_alias(self):
         config = JoystickConfig.from_dict({"mode": "directional"})
         assert config.mode == JoystickMode.DIGITAL
+
+    def test_from_dict_combo_direction_keys(self):
+        """Each direction can be a modifier+key combo (v1.7.2+)."""
+        data = {
+            "mode": "digital",
+            "key_up": ["KEY_LEFTCTRL", "KEY_L"],
+            "key_down": ["KEY_LEFTCTRL", "KEY_4"],
+            "key_left": "KEY_LEFT",
+            "key_right": "KEY_RIGHT",
+        }
+        config = JoystickConfig.from_dict(data)
+        assert config.key_up == ("KEY_LEFTCTRL", "KEY_L")
+        assert config.key_down == ("KEY_LEFTCTRL", "KEY_4")
+        assert config.key_left == ("KEY_LEFT",)
+        assert config.key_right == ("KEY_RIGHT",)
+
+    def test_to_dict_roundtrip_preserves_single_keys_as_strings(self):
+        """Single-key directions serialize as strings (legacy format)."""
+        config = JoystickConfig(
+            mode=JoystickMode.DIGITAL,
+            key_up="KEY_W",
+            key_down="KEY_S",
+            key_left="KEY_A",
+            key_right="KEY_D",
+        )
+        data = config.to_dict()
+        assert data["key_up"] == "KEY_W"
+        assert data["key_down"] == "KEY_S"
+
+    def test_to_dict_roundtrip_serializes_combos_as_lists(self):
+        """Combo directions serialize as lists."""
+        config = JoystickConfig(
+            mode=JoystickMode.DIGITAL,
+            key_up=["KEY_LEFTCTRL", "KEY_L"],
+            key_down=["KEY_LEFTCTRL", "KEY_4"],
+            key_left="KEY_LEFT",
+            key_right="KEY_RIGHT",
+        )
+        data = config.to_dict()
+        assert data["key_up"] == ["KEY_LEFTCTRL", "KEY_L"]
+        assert data["key_down"] == ["KEY_LEFTCTRL", "KEY_4"]
+        assert data["key_left"] == "KEY_LEFT"
+        assert data["key_right"] == "KEY_RIGHT"
 
     def test_from_dict_legacy_directional_mapping_objects(self):
         data = {
@@ -80,11 +125,12 @@ class TestJoystickConfig:
         }
         config = JoystickConfig.from_dict(data)
         assert config.mode == JoystickMode.DIGITAL
-        assert config.key_up == "KEY_W"
-        assert config.key_down == "KEY_S"
-        # Legacy combo mappings are reduced to a usable primary key
-        assert config.key_left == "KEY_LEFTALT"
-        assert config.key_right == "KEY_LEFTALT"
+        assert config.key_up == ("KEY_W",)
+        assert config.key_down == ("KEY_S",)
+        # Combo direction mappings are preserved as tuples (was lossy in v1.7.1
+        # and earlier — only the first key was kept).
+        assert config.key_left == ("KEY_LEFTALT", "KEY_LEFT")
+        assert config.key_right == ("KEY_LEFTALT", "KEY_RIGHT")
 
     def test_to_dict(self):
         config = JoystickConfig(


### PR DESCRIPTION
## Summary

Joystick directions can now bind to modifier+key combos (e.g. \`Ctrl+L\`), not just single keys. Discovered tonight when binding G13 thumbstick UP to EVE's lock-target hotkey.

## Before / after

\`\`\`json
"joystick": {
  "key_up": "KEY_L",                      // ← still works (single key)
  "key_up": ["KEY_LEFTCTRL", "KEY_L"],    // ← NEW (combo)
  ...
}
\`\`\`

## Test plan

- [x] 1720 unit tests pass (3 new for combo support, 1 updated to reflect that combos are no longer lossy)
- [x] ruff clean
- [ ] After merge + v1.7.2 ship: \`pipx upgrade g13-linux\`, restart daemon, bind G13 stick UP to Ctrl+L, lock a target in EVE, verify it locks
🤖 Generated with [Claude Code](https://claude.com/claude-code)